### PR TITLE
feat: copy and delete button for gallery images

### DIFF
--- a/public/assets/css/entitieslist.css
+++ b/public/assets/css/entitieslist.css
@@ -124,6 +124,10 @@ section {
   font-size: 14px;
 }
 
+.hide-dropdown-caret::after {
+  display: none;
+}
+
 /* Media Queries ----------------------------- */
 @media (min-width: 768px) and (max-width: 1024px) {
   #list-example-desktop {
@@ -1199,7 +1203,9 @@ canvas {
   height: auto; /* Maintain aspect ratio */
 }
 
-/* Gallery */
+/*-----------------------------------------------
+|   Gallery
+-----------------------------------------------*/
 .file-preview {
   display: flex;
   flex-direction: column;
@@ -1225,10 +1231,51 @@ div.gslide-media.gslide-inline {
   height: 580px !important;
 }
 
+.gallery-dropdown-menu {
+  padding: 0.2rem 0;
+  margin: 0;
+  list-style: none;
+  min-width: 0;
+}
+
+.gallery-menu {
+  display: flex; /* Ensure it's part of the DOM for transitions */
+  /* Hide initially */
+  visibility: hidden;
+  /* Fully transparent */
+  opacity: 0;
+  padding: 0.2rem 0;
+  margin: 0;
+  background: transparent;
+  border: none;
+  -webkit-box-shadow: unset;
+  box-shadow: unset;
+  min-width: 0;
+  list-style: none;
+  position: absolute;
+  top: 0.3rem;
+  right: 0.5rem;
+}
+
+.gallery-menu li {
+  border-radius: var(--falcon-dropdown-border-radius);
+  background-color: var(--falcon-dropdown-bg);
+}
+
 /* Media Queries ----------------------------- */
 @media (max-width: 768px) {
   .chart-container {
     width: 50%;
     margin: 10px 0;
+  }
+}
+
+@media (min-width: 992px) {
+  .post1:hover .gallery-menu {
+    visibility: visible;
+    opacity: 100;
+    transition:
+      visibility 0s linear 0.15s,
+      opacity 0.25s ease-in-out;
   }
 }

--- a/public/assets/css/entitieslist.css
+++ b/public/assets/css/entitieslist.css
@@ -736,11 +736,11 @@ section {
 }
 
 .picture-placeholder {
+  display: flex;
   /* width: 400px;
   height: 230px;
   border: 2px dashed #ccc;
   display: flex;
-  justify-content: center;
   align-items: center;
   cursor: pointer;
   background-color: #f9f9f9; */
@@ -1231,11 +1231,39 @@ div.gslide-media.gslide-inline {
   height: 580px !important;
 }
 
+.gallery-container {
+  flex-grow: 1;
+  max-height: 700px;
+  /* optional: */
+  /* transition: width 0.15s ease-out; */
+}
+
+.gallery-container a {
+  display: contents; /* ensures children will be affected by the main parent styling */
+}
+
+.gallery-item {
+  object-fit: cover;
+  width: 100%;
+}
+
 .gallery-dropdown-menu {
   padding: 0.2rem 0;
   margin: 0;
   list-style: none;
   min-width: 0;
+}
+
+.gallery-col-4-6 {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 minmax(33%, 50%);
+  flex: 0 0 minmax(33%, 50%);
+  width: 100%;
+}
+
+.gallery-col-width {
+  min-width: 33%;
+  width: 30%;
 }
 
 .gallery-menu {
@@ -1267,6 +1295,21 @@ div.gslide-media.gslide-inline {
   .chart-container {
     width: 50%;
     margin: 10px 0;
+  }
+
+  .picture-placeholder {
+    border: none;
+    height: auto;
+    width: 100%;
+  }
+
+  .picture-placeholder > i,
+  .picture-placeholder > p {
+    display: none;
+  }
+
+  .picture-placeholder > button {
+    display: block;
   }
 }
 

--- a/public/pages/projectdetails.html
+++ b/public/pages/projectdetails.html
@@ -914,7 +914,6 @@
                             </div>
                           </div>
 
-                          <!-- TODO:  this causes issue to the Attachment sections but this is also necessary for this section-->
                           <div class="border-top mt-2 pt-3">
                             <div class="row" id="header-mobile">
                               <div class="col-4 col-sm-4 col-md">
@@ -1088,9 +1087,9 @@
                       <div class="pictures-section mb-3 d-grid" id="pictures-1">
 
 
-                        <div class="picture-placeholder d-flex flex-column " id="picture-1" onclick="document.getElementById('fileInput1').click();" ondragover="handleDragOver(event)" ondrop="handleFileDrop(event, 'picture-1')">
-                          <!-- <p>Drag or Upload Picture</p>
-<i class="fas fa-image"></i> -->
+                        <div class="picture-placeholder flex-column " id="picture-1" onclick="document.getElementById('fileInput1').click();" ondragover="handleDragOver(event)" ondrop="handleFileDrop(event, 'picture-1')">
+                            <!-- <p>Drag or Upload Picture</p>
+                              <i class="fas fa-image"></i> -->
 
                           <i class="cloud-icon">☁</i>
                           <p class="drag-text">Choose an image or drag and drop it here</p>
@@ -1257,10 +1256,13 @@
                     <h5>Gallery Sample</h5>
 
                     <div class="row mx-n1">
-                      <div  class="col-6 p-1 position-relative">
+
+                      <!-- First Image -->
+                      <!-- <div id="gallery-item-1"  class=" col-6 p-1 position-relative"> -->
+                      <div id="gallery-item-1" class="gallery-container d-flex col-6 p-1 position-relative">
                         <!-- in desktop if this is hovered the ul with class gallery-menu will appear -->
-                        <a class="post1" href="../assets/img/generic/4.jpg" data-gallery="gallery-1">
-                          <img class="img-fluid rounded" src="../assets/img/generic/4.jpg" alt="" />
+                        <a class="post1 " href="../assets/img/generic/4.jpg" data-gallery="gallery-1">
+                          <img class="img-fluid rounded gallery-item" src="../assets/img/generic/4.jpg" alt="" />
                           
 
                           <!-- Desktop menu -->
@@ -1273,7 +1275,7 @@
 
                               </li>
                               <li>
-                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-1')">
                                   <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                   Delete
                                 </button>
@@ -1303,7 +1305,7 @@
 
                                 </li>
                                 <li>
-                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-1')">
                                     <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                     Delete
                                   </button>
@@ -1315,9 +1317,10 @@
                         </a>
                       </div>
 
-                      <div class="col-6 p-1 position-relative">
+                    <!-- Second Image -->
+                      <div id="gallery-item-2" class="gallery-container d-flex col-6 p-1 position-relative">
                         <a class="post1" href="../assets/img/generic/5.jpg" data-gallery="gallery-1">
-                          <img class="img-fluid rounded" src="../assets/img/generic/5.jpg" alt="" />
+                          <img class="img-fluid rounded gallery-item" src="../assets/img/generic/5.jpg" alt="" />
 
 
                           <!-- Desktop menu -->
@@ -1330,7 +1333,7 @@
 
                               </li>
                               <li>
-                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-2')">
                                   <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                   Delete
                                 </button>
@@ -1360,7 +1363,7 @@
 
                                 </li>
                                 <li>
-                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-2')">
                                     <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                     Delete
                                   </button>
@@ -1370,12 +1373,13 @@
                             </div>
 
                         </a>
-
                       </div>
 
-                      <div class="col-4 p-1 position-relative">
-                        <a class="post1" href="../assets/img/gallery/4.jpg" data-gallery="gallery-1">
-                          <img class="img-fluid rounded" src="../assets/img/gallery/4.jpg" alt="" />
+                      <!-- Third Image -->
+                      <!-- <div id="gallery-item-3" class="col-4 p-1 position-relative"> -->
+                      <div id="gallery-item-3" class="gallery-container d-flex col-4 p-1 position-relative">
+                        <a class="post1 " href="../assets/img/gallery/4.jpg" data-gallery="gallery-1">
+                          <img class="img-fluid rounded gallery-item "  src="../assets/img/gallery/4.jpg" alt="" />
 
 
                           <!-- Desktop menu -->
@@ -1388,7 +1392,7 @@
 
                               </li>
                               <li>
-                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-3')">
                                   <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                   Delete
                                 </button>
@@ -1418,7 +1422,7 @@
 
                                 </li>
                                 <li>
-                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-3')">
                                     <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                     Delete
                                   </button>
@@ -1430,9 +1434,11 @@
                         </a>
                       </div>
 
-                      <div class="col-4 p-1 position-relative">
+                      <!-- Fourth Image -->
+                      <!-- <div id="gallery-item-4" class=" col-4 p-1 position-relative"> -->
+                      <div id="gallery-item-4" class="gallery-container col-4 p-1 position-relative">
                         <a class="post1" href="#pdfDisplay" data-gallery="gallery-1" data-type="inline">
-                          <div class="file-preview">
+                          <div class="file-preview gallery-item">
                             <i class="fas fa-file-pdf fa-3x"></i>
                             <p class="file-name">dummy-file.PDF</p>
                           </div>
@@ -1447,7 +1453,7 @@
 
                               </li>
                               <li>
-                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-4')">
                                   <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                   Delete
                                 </button>
@@ -1477,7 +1483,7 @@
 
                                 </li>
                                 <li>
-                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-4')">
                                     <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                     Delete
                                   </button>
@@ -1488,9 +1494,10 @@
                         </a>
                       </div>
 
-                      <div class="col-4 p-1 position-relative">
+                      <!-- Fifth Image -->
+                      <div id="gallery-item-5" class="gallery-container d-flex col-4 p-1 position-relative">
                         <a class="post1" href="../assets/img/gallery/3.jpg" data-gallery="gallery-1">
-                          <img class="img-fluid rounded" src="../assets/img/gallery/3.jpg" alt="" />
+                          <img class="img-fluid rounded gallery-item" src="../assets/img/gallery/3.jpg" alt="" />
 
                         <!-- Desktop menu -->
                         <ul class="dropdown-menu gallery-menu gap-2 justify-content-center align-items-center">
@@ -1502,7 +1509,7 @@
 
                           </li>
                           <li>
-                            <button class="dropdown-item"  onclick="event.stopPropagation()">
+                            <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-5')">
                               <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                               Delete
                             </button>
@@ -1532,7 +1539,7 @@
 
                             </li>
                             <li>
-                              <button class="dropdown-item"  onclick="event.stopPropagation()">
+                              <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-5')">
                                 <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                 Delete
                               </button>
@@ -1543,9 +1550,10 @@
                         </a>
                       </div>
 
-                      <div class="col-6 p-1 position-relative">
+                      <!-- Sixth Image -->
+                      <div id="gallery-item-6" class="gallery-container d-flex col-6 p-1 position-relative">
                           <a class="post1" href="../assets/video/beach.mp4" data-gallery="gallery-1" data-type="video">
-                            <div class="file-preview">
+                            <div class="file-preview gallery-item">
                               <i class="fas fa-video fa-3x"></i>
                               <p class="file-name">beach.mp4</p>
                             </div>
@@ -1560,7 +1568,7 @@
 
                               </li>
                               <li>
-                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-6')">
                                   <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                   Delete
                                 </button>
@@ -1590,7 +1598,7 @@
 
                                 </li>
                                 <li>
-                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-6')">
                                     <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                     Delete
                                   </button>
@@ -1601,9 +1609,11 @@
 
                           </a>
                       </div>
-                      <div class="col-6 p-1 position-relative">
+
+                      <!-- Seventh Image -->
+                      <div id="gallery-item-7" class="gallery-container d-flex col-6 p-1 position-relative">
                         <a class="post1" href="#pdfDisplay" data-gallery="gallery-1" data-type="inline">
-                          <div class="file-preview">
+                          <div class="file-preview gallery-item">
                             <i class="fas fa-file-pdf fa-3x"></i>
                             <p class="file-name">dummy-file.PDF</p>
                           </div>
@@ -1618,7 +1628,7 @@
 
                               </li>
                               <li>
-                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-7')">
                                   <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                   Delete
                                 </button>
@@ -1648,7 +1658,7 @@
 
                                 </li>
                                 <li>
-                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <button class="dropdown-item"  onclick="removeGalleryNode(event, 'gallery-item-7')">
                                     <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
                                     Delete
                                   </button>
@@ -3642,13 +3652,9 @@ function removeFile(index) {
       event.stopPropagation();
       event.preventDefault();
 
-      const parent = btnInstance.closest('.post1');
+      const parent = btnInstance.closest('a');
       const src = parent.href;
       copyToClipboard(src);
-
-      console.log('Copying image to clipboard:', src);
-      console.log('Image copied to clipboard:', src);
-
     }
 
     /**
@@ -3666,6 +3672,39 @@ function removeFile(index) {
         }
     }
 
+    /**
+    * Handles node deletion by direct querying the DOM
+    * @param {Event} event 
+    * @param {string} parentId - Direct ID of the parent to remove
+    */
+     function removeGalleryNode(event, parentId) {
+        event.preventDefault();
+        event.stopPropagation();
+        
+        const parentNode = document.getElementById(parentId);
+        if (!parentNode) return;
+
+            const src = parentNode.querySelector('a')?.href;
+
+            // Optional: Show feedback
+            // parentNode.style.opacity = '0';
+            // parentNode.style.width = '0';
+            // parentNode.style.transition = 'width 0.150s ease';
+
+            // Handle image deletion if needed like db call
+            if (src) {
+                // await deleteImageFromDB(imgSrc);
+                console.log('Deleting image from DB:', src);
+            }
+
+            // Remove the node
+            // setTimeout(() =>parentNode.remove() ,150);
+              parentNode.remove();
+            
+
+            // With Flexbox (flex-wrap: wrap), remaining items will automatically reflow
+            
+    }
 
 </script>
 

--- a/public/pages/projectdetails.html
+++ b/public/pages/projectdetails.html
@@ -1243,8 +1243,6 @@
                                   <!-- </td> -->
                               </tr>
 
-
-
                                 </tbody>
                               </table>
                           </div>
@@ -1254,52 +1252,411 @@
                   <!--    Gallery -->
                   <!-- ===============================================-->
 
+                  <!-- current implementation -->
                   <section id="list-item-5">
                     <h5>Gallery Sample</h5>
+
                     <div class="row mx-n1">
-                      <div class="col-6 p-1">
+                      <div  class="col-6 p-1 position-relative">
+                        <!-- in desktop if this is hovered the ul with class gallery-menu will appear -->
                         <a class="post1" href="../assets/img/generic/4.jpg" data-gallery="gallery-1">
                           <img class="img-fluid rounded" src="../assets/img/generic/4.jpg" alt="" />
-                        </a>
-                      </div>
-                      <div class="col-6 p-1">
-                        <a class="post1" href="../assets/img/generic/5.jpg" data-gallery="gallery-1">
-                          <img class="img-fluid rounded" src="../assets/img/generic/5.jpg" alt="" />
-                        </a>
-                      </div>
-                      <div class="col-4 p-1">
-                        <a class="post1" href="../assets/img/gallery/4.jpg" data-gallery="gallery-1">
-                          <img class="img-fluid rounded" src="../assets/img/gallery/4.jpg" alt="" />
+                          
+
+                          <!-- Desktop menu -->
+                          <ul class="dropdown-menu gallery-menu gap-2 justify-content-center align-items-center">
+                              <li>
+                                <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                  <!-- <span class="far fa-copy fs-8"></span> -->
+                                  Copy
+                                </button>
+
+                              </li>
+                              <li>
+                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                  Delete
+                                </button>
+
+                              </li>
+                          </ul>
+
+                          <!-- Mobile view: 3-dot button (Upper Right) -->
+                            <div class="dropdown d-lg-none position-absolute top-0 end-0 ">
+                              <button 
+                                class="btn btn-link dropdown-toggle hide-dropdown-caret" 
+                                type="button"
+                                data-bs-toggle="dropdown" 
+                                aria-expanded="false"
+                                onclick="event.stopPropagation()" 
+                              >
+                                <i class="fas fa-ellipsis-v"></i> <!-- 3 dots icon -->
+                              </button>
+
+                              <!-- Mobile dropdown with buttons -->
+                              <ul class="dropdown-menu dropdown-menu-end gallery-dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                <li>
+                                  <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                    <!-- <span class="far fa-copy fs-8"></span> -->
+                                    Copy
+                                  </button>
+
+                                </li>
+                                <li>
+                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                    <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                    Delete
+                                  </button>
+
+                                </li>
+                              </ul>
+                            </div>
+
                         </a>
                       </div>
 
-                      <div class="col-4 p-1">
+                      <div class="col-6 p-1 position-relative">
+                        <a class="post1" href="../assets/img/generic/5.jpg" data-gallery="gallery-1">
+                          <img class="img-fluid rounded" src="../assets/img/generic/5.jpg" alt="" />
+
+
+                          <!-- Desktop menu -->
+                          <ul class="dropdown-menu gallery-menu gap-2 justify-content-center align-items-center">
+                              <li>
+                                <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                  <!-- <span class="far fa-copy fs-8"></span> -->
+                                  Copy
+                                </button>
+
+                              </li>
+                              <li>
+                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                  Delete
+                                </button>
+
+                              </li>
+                          </ul>
+
+                          <!-- Mobile view: 3-dot button (Upper Right) -->
+                            <div class="dropdown d-lg-none position-absolute top-0 end-0 ">
+                              <button 
+                                class="btn btn-link dropdown-toggle hide-dropdown-caret" 
+                                type="button"
+                                data-bs-toggle="dropdown" 
+                                aria-expanded="false"
+                                onclick="event.stopPropagation()" 
+                              >
+                                <i class="fas fa-ellipsis-v"></i> <!-- 3 dots icon -->
+                              </button>
+
+                              <!-- Mobile dropdown with buttons -->
+                              <ul class="dropdown-menu dropdown-menu-end gallery-dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                <li>
+                                  <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                    <!-- <span class="far fa-copy fs-8"></span> -->
+                                    Copy
+                                  </button>
+
+                                </li>
+                                <li>
+                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                    <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                    Delete
+                                  </button>
+
+                                </li>
+                              </ul>
+                            </div>
+
+                        </a>
+
+                      </div>
+
+                      <div class="col-4 p-1 position-relative">
+                        <a class="post1" href="../assets/img/gallery/4.jpg" data-gallery="gallery-1">
+                          <img class="img-fluid rounded" src="../assets/img/gallery/4.jpg" alt="" />
+
+
+                          <!-- Desktop menu -->
+                          <ul class="dropdown-menu gallery-menu gap-2 justify-content-center align-items-center">
+                              <li>
+                                <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                  <!-- <span class="far fa-copy fs-8"></span> -->
+                                  Copy
+                                </button>
+
+                              </li>
+                              <li>
+                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                  Delete
+                                </button>
+
+                              </li>
+                          </ul>
+
+                          <!-- Mobile view: 3-dot button (Upper Right) -->
+                            <div class="dropdown d-lg-none position-absolute top-0 end-0 ">
+                              <button 
+                                class="btn btn-link dropdown-toggle hide-dropdown-caret" 
+                                type="button"
+                                data-bs-toggle="dropdown" 
+                                aria-expanded="false"
+                                onclick="event.stopPropagation()" 
+                              >
+                                <i class="fas fa-ellipsis-v"></i> <!-- 3 dots icon -->
+                              </button>
+
+                              <!-- Mobile dropdown with buttons -->
+                              <ul class="dropdown-menu dropdown-menu-end gallery-dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                <li>
+                                  <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                    <!-- <span class="far fa-copy fs-8"></span> -->
+                                    Copy
+                                  </button>
+
+                                </li>
+                                <li>
+                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                    <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                    Delete
+                                  </button>
+
+                                </li>
+                              </ul>
+                            </div>
+
+                        </a>
+                      </div>
+
+                      <div class="col-4 p-1 position-relative">
                         <a class="post1" href="#pdfDisplay" data-gallery="gallery-1" data-type="inline">
                           <div class="file-preview">
                             <i class="fas fa-file-pdf fa-3x"></i>
                             <p class="file-name">dummy-file.PDF</p>
                           </div>
+
+                          <!-- Desktop menu -->
+                          <ul class="dropdown-menu gallery-menu gap-2 justify-content-center align-items-center">
+                              <li>
+                                <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                  <!-- <span class="far fa-copy fs-8"></span> -->
+                                  Copy
+                                </button>
+
+                              </li>
+                              <li>
+                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                  Delete
+                                </button>
+
+                              </li>
+                          </ul>
+
+                          <!-- Mobile view: 3-dot button (Upper Right) -->
+                            <div class="dropdown d-lg-none position-absolute top-0 end-0 ">
+                              <button 
+                                class="btn btn-link dropdown-toggle hide-dropdown-caret" 
+                                type="button"
+                                data-bs-toggle="dropdown" 
+                                aria-expanded="false"
+                                onclick="event.stopPropagation()" 
+                              >
+                                <i class="fas fa-ellipsis-v"></i> <!-- 3 dots icon -->
+                              </button>
+
+                              <!-- Mobile dropdown with buttons -->
+                              <ul class="dropdown-menu dropdown-menu-end gallery-dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                <li>
+                                  <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                    <!-- <span class="far fa-copy fs-8"></span> -->
+                                    Copy
+                                  </button>
+
+                                </li>
+                                <li>
+                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                    <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                    Delete
+                                  </button>
+
+                                </li>
+                              </ul>
+                            </div>
                         </a>
                       </div>
-                      <div class="col-4 p-1">
+
+                      <div class="col-4 p-1 position-relative">
                         <a class="post1" href="../assets/img/gallery/3.jpg" data-gallery="gallery-1">
                           <img class="img-fluid rounded" src="../assets/img/gallery/3.jpg" alt="" />
+
+                        <!-- Desktop menu -->
+                        <ul class="dropdown-menu gallery-menu gap-2 justify-content-center align-items-center">
+                          <li>
+                            <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                              <!-- <span class="far fa-copy fs-8"></span> -->
+                              Copy
+                            </button>
+
+                          </li>
+                          <li>
+                            <button class="dropdown-item"  onclick="event.stopPropagation()">
+                              <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                              Delete
+                            </button>
+
+                          </li>
+                        </ul>
+
+                        <!-- Mobile view: 3-dot button (Upper Right) -->
+                        <div class="dropdown d-lg-none position-absolute top-0 end-0 ">
+                          <button 
+                            class="btn btn-link dropdown-toggle hide-dropdown-caret" 
+                            type="button"
+                            data-bs-toggle="dropdown" 
+                            aria-expanded="false"
+                            onclick="event.stopPropagation()" 
+                          >
+                            <i class="fas fa-ellipsis-v"></i> <!-- 3 dots icon -->
+                          </button>
+
+                          <!-- Mobile dropdown with buttons -->
+                          <ul class="dropdown-menu dropdown-menu-end gallery-dropdown-menu" aria-labelledby="dropdownMenuButton">
+                            <li>
+                              <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                <!-- <span class="far fa-copy fs-8"></span> -->
+                                Copy
+                              </button>
+
+                            </li>
+                            <li>
+                              <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                Delete
+                              </button>
+
+                            </li>
+                          </ul>
+                        </div>
                         </a>
                       </div>
-                      <div class="col-6 p-1">
+
+                      <div class="col-6 p-1 position-relative">
                           <a class="post1" href="../assets/video/beach.mp4" data-gallery="gallery-1" data-type="video">
                             <div class="file-preview">
                               <i class="fas fa-video fa-3x"></i>
                               <p class="file-name">beach.mp4</p>
                             </div>
+
+                          <!-- Desktop menu -->
+                          <ul class="dropdown-menu gallery-menu gap-2 justify-content-center align-items-center">
+                              <li>
+                                <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                  <!-- <span class="far fa-copy fs-8"></span> -->
+                                  Copy
+                                </button>
+
+                              </li>
+                              <li>
+                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                  Delete
+                                </button>
+
+                              </li>
+                          </ul>
+
+                          <!-- Mobile view: 3-dot button (Upper Right) -->
+                            <div class="dropdown d-lg-none position-absolute top-0 end-0 ">
+                              <button 
+                                class="btn btn-link dropdown-toggle hide-dropdown-caret" 
+                                type="button"
+                                data-bs-toggle="dropdown" 
+                                aria-expanded="false"
+                                onclick="event.stopPropagation()" 
+                              >
+                                <i class="fas fa-ellipsis-v"></i> <!-- 3 dots icon -->
+                              </button>
+
+                              <!-- Mobile dropdown with buttons -->
+                              <ul class="dropdown-menu dropdown-menu-end gallery-dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                <li>
+                                  <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                    <!-- <span class="far fa-copy fs-8"></span> -->
+                                    Copy
+                                  </button>
+
+                                </li>
+                                <li>
+                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                    <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                    Delete
+                                  </button>
+
+                                </li>
+                              </ul>
+                            </div>
+
                           </a>
                       </div>
-                      <div class="col-6 p-1">
+                      <div class="col-6 p-1 position-relative">
                         <a class="post1" href="#pdfDisplay" data-gallery="gallery-1" data-type="inline">
                           <div class="file-preview">
                             <i class="fas fa-file-pdf fa-3x"></i>
                             <p class="file-name">dummy-file.PDF</p>
                           </div>
+
+                          <!-- Desktop menu -->
+                          <ul class="dropdown-menu gallery-menu gap-2 justify-content-center align-items-center">
+                              <li>
+                                <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                  <!-- <span class="far fa-copy fs-8"></span> -->
+                                  Copy
+                                </button>
+
+                              </li>
+                              <li>
+                                <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                  <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                  Delete
+                                </button>
+
+                              </li>
+                          </ul>
+
+                          <!-- Mobile view: 3-dot button (Upper Right) -->
+                            <div class="dropdown d-lg-none position-absolute top-0 end-0 ">
+                              <button 
+                                class="btn btn-link dropdown-toggle hide-dropdown-caret" 
+                                type="button"
+                                data-bs-toggle="dropdown" 
+                                aria-expanded="false"
+                                onclick="event.stopPropagation()" 
+                              >
+                                <i class="fas fa-ellipsis-v"></i> <!-- 3 dots icon -->
+                              </button>
+
+                              <!-- Mobile dropdown with buttons -->
+                              <ul class="dropdown-menu dropdown-menu-end gallery-dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                <li>
+                                  <button class="dropdown-item"  onclick="copyImageToClipboard(this)">
+                                    <!-- <span class="far fa-copy fs-8"></span> -->
+                                    Copy
+                                  </button>
+
+                                </li>
+                                <li>
+                                  <button class="dropdown-item"  onclick="event.stopPropagation()">
+                                    <!-- <span class="far fa-trash-alt text-danger fs-8"></span> -->
+                                    Delete
+                                  </button>
+
+                                </li>
+                              </ul>
+                            </div>
+
                         </a>
                       </div>
 
@@ -1321,6 +1678,78 @@
                         </object>
                       </div>
                     </div>
+
+
+
+                    <!-- **** Image Gallery Implementation **** -->
+                    <!-- <div class="row mx-n1"> -->
+                    <!--   <div class="col-6 p-1"> -->
+                    <!--     <a class="post1" href="../assets/img/generic/4.jpg" data-gallery="gallery-1"> -->
+                    <!--       <img class="img-fluid rounded" src="../assets/img/generic/4.jpg" alt="" /> -->
+                    <!--     </a> -->
+                    <!--   </div> -->
+                    <!--   <div class="col-6 p-1"> -->
+                    <!--     <a class="post1" href="../assets/img/generic/5.jpg" data-gallery="gallery-1"> -->
+                    <!--       <img class="img-fluid rounded" src="../assets/img/generic/5.jpg" alt="" /> -->
+                    <!--     </a> -->
+                    <!--   </div> -->
+                    <!--   <div class="col-4 p-1"> -->
+                    <!--     <a class="post1" href="../assets/img/gallery/4.jpg" data-gallery="gallery-1"> -->
+                    <!--       <img class="img-fluid rounded" src="../assets/img/gallery/4.jpg" alt="" /> -->
+                    <!--     </a> -->
+                    <!--   </div> -->
+                    <!---->
+                    <!--   <div class="col-4 p-1"> -->
+                    <!--     <a class="post1" href="#pdfDisplay" data-gallery="gallery-1" data-type="inline"> -->
+                    <!--       <div class="file-preview"> -->
+                    <!--         <i class="fas fa-file-pdf fa-3x"></i> -->
+                    <!--         <p class="file-name">dummy-file.PDF</p> -->
+                    <!--       </div> -->
+                    <!--     </a> -->
+                    <!--   </div> -->
+                    <!--   <div class="col-4 p-1"> -->
+                    <!--     <a class="post1" href="../assets/img/gallery/3.jpg" data-gallery="gallery-1"> -->
+                    <!--       <img class="img-fluid rounded" src="../assets/img/gallery/3.jpg" alt="" /> -->
+                    <!--     </a> -->
+                    <!--   </div> -->
+                    <!--   <div class="col-6 p-1"> -->
+                    <!--       <a class="post1" href="../assets/video/beach.mp4" data-gallery="gallery-1" data-type="video"> -->
+                    <!--         <div class="file-preview"> -->
+                    <!--           <i class="fas fa-video fa-3x"></i> -->
+                    <!--           <p class="file-name">beach.mp4</p> -->
+                    <!--         </div> -->
+                    <!--       </a> -->
+                    <!--   </div> -->
+                    <!--   <div class="col-6 p-1"> -->
+                    <!--     <a class="post1" href="#pdfDisplay" data-gallery="gallery-1" data-type="inline"> -->
+                    <!--       <div class="file-preview"> -->
+                    <!--         <i class="fas fa-file-pdf fa-3x"></i> -->
+                    <!--         <p class="file-name">dummy-file.PDF</p> -->
+                    <!--       </div> -->
+                    <!--     </a> -->
+                    <!--   </div> -->
+                    <!---->
+                    <!--   <!-- Div to display PDF --> 
+                    <!--   <div id="pdfDisplay" style="margin: 10px; display: none"> -->
+                    <!--     <object -->
+                    <!--       data="../assets/docs/dummy-file.pdf" -->
+                    <!--       type="application/pdf" -->
+                    <!--       width="100%" -->
+                    <!--       height="100%" -->
+                    <!--       style="border: none;" -->
+                    <!--       aria-labelledby="PDF Preview" -->
+                    <!--       title="PDF Preview" -->
+                    <!--     > -->
+                    <!--       <p> -->
+                    <!--         Your browser does not support PDFs. -->
+                    <!--         <a href="../assets/docs/dummy-file.pdf">Download the PDF</a> -->
+                    <!--       </p> -->
+                    <!--     </object> -->
+                    <!--   </div> -->
+                    <!-- </div> -->
+
+
+                    <!-- ****FILE LIST IMPLEMENTATION**** -->
 
                     <!-- <h5 class="mt-3">File List</h5> -->
                     <!-- <div class="files"> -->
@@ -2014,8 +2443,8 @@
                             </div>
                           </div>
                         </div>
-                      </section>
-                                        </div>
+                    </div>
+                </section>
             </div>
           </div>
 
@@ -2043,7 +2472,7 @@
 
 
 
-          </footer>
+          <!-- </footer> -->
         </div>
         <div class="modal fade" id="authentication-modal" tabindex="-1" role="dialog" aria-labelledby="authentication-modal-label" aria-hidden="true">
           <div class="modal-dialog mt-6" role="document">
@@ -3200,6 +3629,45 @@ function removeFile(index) {
 
 </script>
 
+    <!-- Gallery Preview Implementation -->
+<script>
+
+    /**
+     * Copies the image source to the clipboard.
+     *
+     * @param {HTMLElement} btnInstance - The button element that triggered the copy
+     */
+    function copyImageToClipboard(btnInstance) {
+      // make sure the button doesnt propagate and prevent default
+      event.stopPropagation();
+      event.preventDefault();
+
+      const parent = btnInstance.closest('.post1');
+      const src = parent.href;
+      copyToClipboard(src);
+
+      console.log('Copying image to clipboard:', src);
+      console.log('Image copied to clipboard:', src);
+
+    }
+
+    /**
+      * Copy URL to clipboard
+      * @param {string} url - URL to copy
+      * @param {HTMLElement} button - Button element that triggered copy
+      */
+    async function copyToClipboard(url) {
+        try {
+            await navigator.clipboard.writeText(url);
+            // showTooltip(button, 'Copied!');
+        } catch (err) {
+            showTooltip(button, 'Failed to copy');
+            // console.error('Failed to copy:', err);
+        }
+    }
+
+
+</script>
 
 <!-- Load jQuery (if needed) and Flatpickr JS from CDN -->
 <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>


### PR DESCRIPTION
## Copy button
copy: will copy the src of the image to clipboard.
style: drop down implementation in mobile view and hover on desktop view

## Delete button 
Caveat/Issue: Need to manipulate the Dom , and layout shifting on sudden removal of node element. 
Fix: 
- direct query of parent and using .remove() without mapping while giving room for a database call logic. 
- used flex box + flex-wrap + flex+grow to dynamically change the image depending on the available width of the layout.

### mobile view
![Screenshot from 2025-01-21 15-26-46](https://github.com/user-attachments/assets/2c9e8660-7b13-4980-a9db-c446653e31b5)

### desktop
![Screenshot from 2025-01-21 15-25-54](https://github.com/user-attachments/assets/a9a3954b-a8e5-434f-8209-87153931debe)

### video preview
[gallery-desk-no-ani.webm](https://github.com/user-attachments/assets/76ef356d-0c10-4753-b79a-90f66a436b8c)

